### PR TITLE
Pagination for getting members using Bot API

### DIFF
--- a/Source/Microsoft.Teams.Apps.RemoteSupport.Common/Models/OnCallSMEDetail.cs
+++ b/Source/Microsoft.Teams.Apps.RemoteSupport.Common/Models/OnCallSMEDetail.cs
@@ -22,5 +22,17 @@ namespace Microsoft.Teams.Apps.RemoteSupport.Common.Models
         /// </summary>
         [JsonProperty("objectid")]
         public string ObjectId { get; set; }
+
+        /// <summary>
+        /// Gets or sets object Id of on call expert .
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets email Id of on call expert.
+        /// </summary>
+        [JsonProperty("email")]
+        public string Email { get; set; }
     }
 }

--- a/Source/Microsoft.Teams.Apps.RemoteSupport/ClientApp/src/components/manage-experts.tsx
+++ b/Source/Microsoft.Teams.Apps.RemoteSupport/ClientApp/src/components/manage-experts.tsx
@@ -287,13 +287,13 @@ class ManageExperts extends React.Component<{}, IState>
         if (expertListResponse.status === 200) {
 
             let allMembers = this.state.allMembers;
-            let OnCallExpertsList: Array<any> = [];
+            let onCallExpertsList: Array<string> = [];
             this.state.onCallExperts.forEach((onCallExpertsDetail) => {
                 let member = allMembers.find(element => element.aadobjectid == onCallExpertsDetail.key);
-                OnCallExpertsList.push(member.content);
+                onCallExpertsList.push(member.aadobjectid);
             });
 
-            let toBot = { Command: Constants.updateExpertListCommand, OnCallExpertsList: OnCallExpertsList, OnCallSupportCardActivityId: this.activityId, OnCallSupportId: expertListResponse.data };
+            let toBot = { Command: Constants.updateExpertListCommand, OnCallExpertsList: onCallExpertsList, OnCallSupportCardActivityId: this.activityId, OnCallSupportId: expertListResponse.data };
 
             microsoftTeams.getContext((context) => {
                 microsoftTeams.tasks.submitTask(toBot);

--- a/Source/Microsoft.Teams.Apps.RemoteSupport/Helpers/TeamMemberCacheHelper.cs
+++ b/Source/Microsoft.Teams.Apps.RemoteSupport/Helpers/TeamMemberCacheHelper.cs
@@ -1,0 +1,63 @@
+﻿// <copyright file="TeamMemberCacheHelper.cs" company="Microsoft">
+// Copyright (c) Microsoft. All rights reserved.
+// </copyright>
+
+namespace Microsoft.Teams.Apps.RemoteSupport.Helpers
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Bot.Builder;
+    using Microsoft.Bot.Builder.Teams;
+    using Microsoft.Bot.Schema.Teams;
+    using Microsoft.Extensions.Caching.Memory;
+
+    /// <summary>
+    /// Class that handles the card configuration.
+    /// </summary>
+    public static class TeamMemberCacheHelper
+    {
+        /// <summary>
+        /// Cache key for expert details
+        /// </summary>
+        private const string ExpertCollectionCacheKey = "_expertCollectionKey";
+
+        /// <summary>
+        /// Sets the team members cache duration.
+        /// </summary>
+        private static readonly TimeSpan CacheDuration = TimeSpan.FromDays(1);
+
+        /// <summary>
+        /// Provide team members information.
+        /// </summary>
+        /// <param name="memoryCache">MemoryCache instance for caching on call expert objectId's.</param>
+        /// <param name="turnContext">Provides context for a turn of a bot.</param>
+        /// <param name="userId">Describes a user Id.</param>
+        /// <param name="teamId">Describes a team Id.</param>
+        /// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
+        /// <returns>Returns team members information from cache.</returns>
+        public static async Task<TeamsChannelAccount> GetMemberInfoAsync(IMemoryCache memoryCache, ITurnContext turnContext, string userId, string teamId, CancellationToken cancellationToken)
+        {
+            bool isCacheEntryExists = memoryCache.TryGetValue(ExpertCollectionCacheKey + userId, out TeamsChannelAccount memberInformation);
+
+            if (!isCacheEntryExists)
+            {
+                if (teamId != null)
+                {
+                    memberInformation = await TeamsInfo.GetTeamMemberAsync(turnContext, userId, teamId);
+                }
+                else
+                {
+                    memberInformation = await TeamsInfo.GetMemberAsync(turnContext, userId, cancellationToken);
+                }
+
+                if (memberInformation != null)
+                {
+                    memoryCache.Set(ExpertCollectionCacheKey + userId, memberInformation, CacheDuration);
+                }
+            }
+
+            return memberInformation;
+        }
+    }
+}

--- a/Source/Microsoft.Teams.Apps.RemoteSupport/Microsoft.Teams.Apps.RemoteSupport.csproj
+++ b/Source/Microsoft.Teams.Apps.RemoteSupport/Microsoft.Teams.Apps.RemoteSupport.csproj
@@ -17,7 +17,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.12.0" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.7.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.13.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Issue details - TeamsInfo.GetTeamMembersAsync method to retrieve information for one or more members of a chat or team has been deprecated.

Solution details - Changed TeamsInfo.GetTeamMembersAsync method logic.
Implemented caching to handle team member details using getMemberAsync method.
Note - The limit of team members is 15.

Testing done -
Tested caching by adding users, removing few from experts list.